### PR TITLE
Fixed examples failing validation, added base names to assist underst…

### DIFF
--- a/_sources/alignments/cityjson-transform/examples.yaml
+++ b/_sources/alignments/cityjson-transform/examples.yaml
@@ -1,10 +1,12 @@
 examples:
   - title: CityJSON Cube
+    base-output-filename: cityjson-cube
     snippets:
       - language: json
         ref: examples/cube.city.json
 
   - title: CityJSON Two Buildings
+    base-output-filename: cityjson-buildings
     snippets:
       - language: json
         ref: examples/twobuildings.city.json

--- a/_sources/datatypes/oriented-ref/examples.yaml
+++ b/_sources/datatypes/oriented-ref/examples.yaml
@@ -2,6 +2,7 @@
   content: |
     An oriented reference to an edge feature, used as an element of a Ring's directed_references array.
     The '+' orientation means the edge is traversed in its natural direction.
+  base-output-filename: oriented-reference
   snippets:
     - language: json
       code: |
@@ -15,6 +16,7 @@
     An oriented reference to an edge feature traversed in reverse.
     The '-' orientation means the edge is used in the opposite direction to its definition.
     This allows the same edge to serve as a boundary of two adjacent faces without duplication.
+  base-output-filename: edge-reference
   snippets:
     - language: json
       code: |

--- a/_sources/datatypes/topology/examples.yaml
+++ b/_sources/datatypes/topology/examples.yaml
@@ -2,6 +2,7 @@
   content: |
     A topology object for an edge feature using plain string ID references.
     The 'references' array names the two point features that form the line's endpoints.
+  base-output-filename: line
   snippets:
     - language: json
       ref: examples/line.json
@@ -11,6 +12,7 @@
   content: |
     A topology object for an edge feature using plain string ID references.
     The 'references' array names the two point features that form the line's endpoints.
+  base-output-filename: relationship
   snippets:
     - language: json
       ref: examples/relationship.json
@@ -18,8 +20,9 @@
 
 - title: Ring topology (directed_references style)
   content: |
-    A Ring topology object using directed_references — each element has a 'ref' (Edge feature ID)
+    A Ring topology object uses directed_references — each element has a 'ref' (Edge feature ID)
     and an 'orientation' ('+' or '-'). Mutually exclusive with 'references'.
+  base-output-filename: ring-topology
   snippets:
     - language: json
       code: |
@@ -33,49 +36,53 @@
           ]
         }
 
-- title: Face topology (rings of directed_references)
+- title: Face topology (directed_references to Ring features)
   content: |
-    A Face topology object. The 'rings' array contains Ring objects, each with
-    directed_references to Edge features. The first ring is the outer boundary.
-    'references' and 'directed_references' must not both be present.
+    A Face topology object uses directed_references to reference Ring features.
+    Each element has a 'ref' (Ring feature ID) and an 'orientation' ('+' or '-').
+    Mutually exclusive with 'references'.
+  base-output-filename: face-topology
   snippets:
     - language: json
       code: |
         {
           "type": "Face",
-          "rings": [
-            {
-              "type": "Ring",
-              "directed_references": [
-                { "ref": "uuid:c60507ba-226b-4e49-a702-e9afef899b23", "orientation": "+" },
-                { "ref": "uuid:7dc1cc1c-8e7f-4666-9f52-4e6c2e6f57ac", "orientation": "+" },
-                { "ref": "uuid:83ff2cdf-6c58-4e7b-ba55-e084eff8c569", "orientation": "+" },
-                { "ref": "uuid:d69c596c-134e-4216-9bf6-d0f10e6886d8", "orientation": "+" }
-              ]
-            }
+          "directed_references": [
+            { "ref": "uuid:c60507ba-226b-4e49-a702-e9afef899b23", "orientation": "+" }
           ]
         }
 
-- title: Solid topology (shells of directed_references)
+- title: Shell topology (directed_references to Face features)
   content: |
-    A Solid topology object. The 'shells' array contains Shell objects, each with
-    directed_references to Face features forming the closed boundary surface.
+    A Shell topology object uses directed_references to reference Face features.
+    Each element has a 'ref' (Face feature ID) and an 'orientation' ('+' or '-').
+    Mutually exclusive with 'references'.
+  base-output-filename: shell-topology
+  snippets:
+    - language: json
+      code: |
+        {
+          "type": "Shell",
+          "directed_references": [
+            { "ref": "uuid:4ac3b91b-eeb7-428c-b5e9-7e8a2f0998ae", "orientation": "+" },
+            { "ref": "uuid:4ac3b91b-eeb7-428c-b5e9-7e8a3f0998ae", "orientation": "+" },
+            { "ref": "uuid:4ac3b91b-eeb7-428c-b7e9-7e8a3f0998ae", "orientation": "-" },
+            { "ref": "uuid:4ac4b91b-eeb7-428c-b5e9-7e8a3f0998ae", "orientation": "+" }
+          ]
+        }
+
+- title: Solid topology (directed_references to Shell features)
+  content: |
+    A Solid topology object uses directed_references to reference Shell features.
+    Each element has a 'ref' (Shell feature ID) and an 'orientation' ('+' or '-').
+    Mutually exclusive with 'references'.
+  base-output-filename: solid-topology
   snippets:
     - language: json
       code: |
         {
           "type": "Solid",
-          "shells": [
-            {
-              "type": "Shell",
-              "directed_references": [
-                { "ref": "uuid:4ac3b91b-eeb7-428c-b5e9-7e8a3f0998ae", "orientation": "+" },
-                { "ref": "uuid:4a294022-4864-49c7-8cee-f9e43360bc4e", "orientation": "+" },
-                { "ref": "uuid:01947f47-ee13-44a9-85a4-2bcb4881982a", "orientation": "+" },
-                { "ref": "uuid:607a3363-3eb7-4ce6-a633-86d2e565692b", "orientation": "+" },
-                { "ref": "uuid:3c1f5c4b-d842-40b6-a332-99d50015fa8f", "orientation": "+" },
-                { "ref": "uuid:2387ae98-9236-42fe-9414-c45b99954c41", "orientation": "+" }
-              ]
-            }
+          "directed_references": [
+            { "ref": "uuid:4ac3b91b-eeb7-428c-b5e9-7e8a3f0998ae", "orientation": "+" }
           ]
         }

--- a/_sources/features/topo-arc/examples.yaml
+++ b/_sources/features/topo-arc/examples.yaml
@@ -1,14 +1,15 @@
 - title: Example GeoJSON feature using ArcWithCenter topology
   content: |-
-    Arc with Center example.
+    Arc with Centre example.
 
-    Topology defined by 2 end points and a centre that are references to features with point geometry.
+    Topology is defined by 2 end points and a centre that are references to features with point geometry.
 
     ![Example](assets/arc-by-center.png)
     
-    radius and arcLength are implicit but may be provided as optional properties of the feature.
+    Radius and arcLength are implicit but may be provided as optional properties of the feature.
 
 
+  base-output-filename: arc-with-centre
   snippets:
     - language: json
       base-uri: http://www.example.com/features/
@@ -25,6 +26,7 @@
 
       ![Example](assets/arc.png)
 
+  base-output-filename: arc
   snippets:
     - language: json
       base-uri: http://www.example.com/features/
@@ -39,6 +41,7 @@
 
       ![Example](assets/arc-by-chord.png)
 
+  base-output-filename: arc-by-chord
   snippets:
     - language: json
       base-uri: http://www.example.com/features/
@@ -53,6 +56,7 @@
     
       ![Example](assets/circle-with-center.png)
 -
+  base-output-filename: circle
   snippets:
     - language: json
       base-uri: http://www.example.com/features/
@@ -67,6 +71,7 @@
 
     ![Example](assets/spline.png)
 -
+  base-output-filename: spline
   snippets:
     - language: json
       base-uri: http://www.example.com/features/
@@ -79,6 +84,7 @@
   content: |-
     Cubic Spline with Tangents example.
 
+  base-output-filename: spline-with-tangents
   snippets:
     - language: json
       base-uri: http://www.example.com/features/

--- a/_sources/features/topo-face/examples.yaml
+++ b/_sources/features/topo-face/examples.yaml
@@ -4,6 +4,8 @@
     Edge and Point features it references. The face outer Ring has 4 oriented Edge references
     in its directed_references array. Point geometry provides actual coordinates;
     edge and face geometry are null (topology-only).
+
+  base-output-filename: face
   snippets:
     - language: json
       ref: examples/face-with-context.json
@@ -11,19 +13,26 @@
 
 - title: Simple Face (4-edge rectangular face)
   content: |
-    A Face feature with a single outer Ring containing four oriented Edge references
-    in directed_references. All edges are traversed in the '+' (forward) direction,
-    closing the loop. geometry is null — coordinates are derived from the referenced edges and points.
+    A Face feature with a single outer Ring containing four oriented Edge references.
+    The Ring feature is referenced from the Face via directed_references. All edges are
+    traversed in the '+' (forward) direction, closing the loop. Face geometry is null —
+    coordinates are derived from the referenced edges and points.
+
+  base-output-filename: 4-edge-face
   snippets:
     - language: json
       ref: examples/face-simple.json
+      schema-ref: "#testCollection"
 
 - title: Face with 6 edges and mixed orientations
   content: |
-    An L-shaped Face with 6 edges in its outer Ring directed_references. Some edges are
+    A hexagonal-shaped Face with 6 edges in its outer Ring directed_references. Some edges are
     shared with adjacent faces and therefore appear with '-' (reverse) orientation,
     reflecting the shared boundary convention.
+
+  base-output-filename: 6-edge-face
   snippets:
     - language: json
       ref: examples/face-6edge.json
+      schema-ref: "#testCollection"
 

--- a/_sources/features/topo-face/examples/face-6edge.json
+++ b/_sources/features/topo-face/examples/face-6edge.json
@@ -1,47 +1,67 @@
 {
-  "id": "uuid:607a3363-3eb7-4ce6-a633-86d2e565692b",
-  "type": "Feature",
-  "geometry": null,
-  "topology": {
-    "type": "Face",
-    "rings": [
-      {
+  "type": "FeatureCollection",
+  "features": [],
+  "rings": [
+    {
+      "id": "uuid:c60507ba-226b-4e49-a702-e9afef899b23",
+      "type": "Feature",
+      "geometry": null,
+      "topology": {
         "type": "Ring",
         "directed_references": [
           {
-            "ref": "uuid:8582d9c2-6053-495a-8413-f5493691c0de",
-            "orientation": "-"
-          },
-          {
-            "ref": "uuid:7dc1cc1c-8e7f-4666-9f52-4e6c2e6f57ac",
-            "orientation": "-"
-          },
-          {
-            "ref": "uuid:4c2a6434-03b0-4aa2-85ea-a9fcaea41555",
-            "orientation": "-"
-          },
-          {
-            "ref": "uuid:921e2351-efbf-48be-85d3-eedc0dc2ddc0",
+            "ref": "uuid:3af6ffd3-355f-48a4-badf-dcc136d547f3",
             "orientation": "+"
           },
           {
-            "ref": "uuid:73f88b47-78ab-474d-9c62-73dfefd0dd5d",
+            "ref": "uuid:cdf01952-2518-4523-a3a7-363be4b8bc3f",
             "orientation": "+"
           },
           {
-            "ref": "uuid:7aa2a76d-9d5c-4540-9f2e-d8bcf36fadb5",
+            "ref": "uuid:47d12439-8724-4a64-b43b-5f2f7ff9ce1a",
+            "orientation": "+"
+          },
+          {
+            "ref": "uuid:23641631-470f-4c4b-981d-23ccb35d6a51",
+            "orientation": "+"
+          },
+          {
+            "ref": "uuid:23141631-470f-4c4b-981d-23ccb35d6a51",
+            "orientation": "-"
+          },
+          {
+            "ref": "uuid:23641631-470f-4d4b-981d-23ccb35d6a51",
+            "orientation": "-"
+          }
+        ]
+      },
+      "properties": {
+        "circumference": 60.0
+      }
+    }
+  ],
+  "faces": [
+    {
+      "id": "uuid:4ac3b91b-eeb7-428c-b5e9-7e8a3f0998ae",
+      "type": "Feature",
+      "geometry": null,
+      "topology": {
+        "type": "Face",
+        "directed_references": [
+          {
+            "ref": "uuid:c60507ba-226b-4e49-a702-e9afef899b23",
             "orientation": "+"
           }
         ]
+      },
+      "properties": {
+        "normal": [
+          1.0,
+          0.0,
+          0.0
+        ],
+        "area": 260.0
       }
-    ]
-  },
-  "properties": {
-    "normal": [
-      0.0,
-      0.0,
-      1.0
-    ],
-    "area": 56.0
-  }
+    }
+  ]
 }

--- a/_sources/features/topo-face/examples/face-simple.json
+++ b/_sources/features/topo-face/examples/face-simple.json
@@ -1,39 +1,59 @@
 {
-  "id": "uuid:4ac3b91b-eeb7-428c-b5e9-7e8a3f0998ae",
-  "type": "Feature",
-  "geometry": null,
-  "topology": {
-    "type": "Face",
-    "rings": [
-      {
+  "type": "FeatureCollection",
+  "features": [],
+  "rings": [
+    {
+      "id": "uuid:c60507ba-226b-4e49-a702-e9afef899b23",
+      "type": "Feature",
+      "geometry": null,
+      "topology": {
         "type": "Ring",
+        "directed_references": [
+          {
+            "ref": "uuid:3af6ffd3-355f-48a4-badf-dcc136d547f3",
+            "orientation": "+"
+          },
+          {
+            "ref": "uuid:cdf01952-2518-4523-a3a7-363be4b8bc3f",
+            "orientation": "+"
+          },
+          {
+            "ref": "uuid:47d12439-8724-4a64-b43b-5f2f7ff9ce1a",
+            "orientation": "+"
+          },
+          {
+            "ref": "uuid:23641631-470f-4c4b-981d-23ccb35d6a51",
+            "orientation": "+"
+          }
+        ]
+      },
+      "properties": {
+        "circumference": 40.0
+      }
+    }
+  ],
+  "faces": [
+    {
+      "id": "uuid:4ac3b91b-eeb7-428c-b5e9-7e8a3f0998ae",
+      "type": "Feature",
+      "geometry": null,
+      "topology": {
+        "type": "Face",
         "directed_references": [
           {
             "ref": "uuid:c60507ba-226b-4e49-a702-e9afef899b23",
             "orientation": "+"
-          },
-          {
-            "ref": "uuid:7dc1cc1c-8e7f-4666-9f52-4e6c2e6f57ac",
-            "orientation": "+"
-          },
-          {
-            "ref": "uuid:83ff2cdf-6c58-4e7b-ba55-e084eff8c569",
-            "orientation": "+"
-          },
-          {
-            "ref": "uuid:d69c596c-134e-4216-9bf6-d0f10e6886d8",
-            "orientation": "+"
           }
         ]
+      },
+      "properties": {
+        "normal": [
+          1.0,
+          0.0,
+          0.0
+        ],
+        "area": 100.0
       }
-    ]
-  },
-  "properties": {
-    "normal": [
-      1.0,
-      0.0,
-      0.0
-    ],
-    "area": 24.0
-  }
+    }
+  ]
 }

--- a/_sources/features/topo-face/examples/face-with-context.json
+++ b/_sources/features/topo-face/examples/face-with-context.json
@@ -9,9 +9,9 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          18.0,
           10.0,
-          3.0
+          0.0,
+          0.0
         ]
       },
       "properties": null
@@ -22,9 +22,9 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          18.0,
           10.0,
-          6.0
+          10.0,
+          0.0
         ]
       },
       "properties": null
@@ -35,9 +35,9 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          18.0,
-          2.0,
-          6.0
+          10.0,
+          10.0,
+          10.0
         ]
       },
       "properties": null
@@ -49,8 +49,8 @@
         "type": "Point",
         "coordinates": [
           18.0,
-          2.0,
-          3.0
+          0.0,
+          10.0
         ]
       },
       "properties": null
@@ -58,7 +58,7 @@
   ],
   "edges": [
     {
-      "id": "uuid:c60507ba-226b-4e49-a702-e9afef899b23",
+      "id": "uuid:3af6ffd3-355f-48a4-badf-dcc136d547f3",
       "type": "Feature",
       "geometry": null,
       "topology": {
@@ -69,11 +69,11 @@
         ]
       },
       "properties": {
-        "length": 3.0
+        "length": 10.0
       }
     },
     {
-      "id": "uuid:7dc1cc1c-8e7f-4666-9f52-4e6c2e6f57ac",
+      "id": "uuid:cdf01952-2518-4523-a3a7-363be4b8bc3f",
       "type": "Feature",
       "geometry": null,
       "topology": {
@@ -84,11 +84,11 @@
         ]
       },
       "properties": {
-        "length": 8.0
+        "length": 10.0
       }
     },
     {
-      "id": "uuid:83ff2cdf-6c58-4e7b-ba55-e084eff8c569",
+      "id": "uuid:47d12439-8724-4a64-b43b-5f2f7ff9ce1a",
       "type": "Feature",
       "geometry": null,
       "topology": {
@@ -99,11 +99,11 @@
         ]
       },
       "properties": {
-        "length": 3.0
+        "length": 10.0
       }
     },
     {
-      "id": "uuid:d69c596c-134e-4216-9bf6-d0f10e6886d8",
+      "id": "uuid:23641631-470f-4c4b-981d-23ccb35d6a51",
       "type": "Feature",
       "geometry": null,
       "topology": {
@@ -114,38 +114,52 @@
         ]
       },
       "properties": {
-        "length": 8.0
+        "length": 10.0
+      }
+    }
+  ],
+  "rings": [
+    {
+      "id": "uuid:fbcc1a1e-5e9a-47c4-b3b0-d7812f585ab8",
+      "type": "Feature",
+      "geometry": null,
+      "topology": {
+        "type": "Ring",
+        "directed_references": [
+          {
+            "ref": "uuid:3af6ffd3-355f-48a4-badf-dcc136d547f3",
+            "orientation": "+"
+          },
+          {
+            "ref": "uuid:cdf01952-2518-4523-a3a7-363be4b8bc3f",
+            "orientation": "+"
+          },
+          {
+            "ref": "uuid:47d12439-8724-4a64-b43b-5f2f7ff9ce1a",
+            "orientation": "+"
+          },
+          {
+            "ref": "uuid:23641631-470f-4c4b-981d-23ccb35d6a51",
+            "orientation": "+"
+          }
+        ]
+      },
+      "properties": {
+        "circumference": 40.00
       }
     }
   ],
   "faces": [
     {
-      "id": "uuid:4ac3b91b-eeb7-428c-b5e9-7e8a3f0998ae",
+      "id": "uuid:2c21efab-db80-4dd0-96c0-59a63f956d5b",
       "type": "Feature",
       "geometry": null,
       "topology": {
         "type": "Face",
-        "rings": [
+        "directed_references": [
           {
-            "type": "Ring",
-            "directed_references": [
-              {
-                "ref": "uuid:c60507ba-226b-4e49-a702-e9afef899b23",
-                "orientation": "+"
-              },
-              {
-                "ref": "uuid:7dc1cc1c-8e7f-4666-9f52-4e6c2e6f57ac",
-                "orientation": "+"
-              },
-              {
-                "ref": "uuid:83ff2cdf-6c58-4e7b-ba55-e084eff8c569",
-                "orientation": "+"
-              },
-              {
-                "ref": "uuid:d69c596c-134e-4216-9bf6-d0f10e6886d8",
-                "orientation": "+"
-              }
-            ]
+            "ref": "uuid:fbcc1a1e-5e9a-47c4-b3b0-d7812f585ab8",
+            "orientation": "+"
           }
         ]
       },
@@ -153,9 +167,10 @@
         "normal": [
           1.0,
           0.0,
-          -0.0
+          0.0
         ],
-        "area": 24.0
+        "area": 100.0,
+        "description": "East-facing boundary face, [Cube]"
       }
     }
   ]

--- a/_sources/features/topo-face/schema.json
+++ b/_sources/features/topo-face/schema.json
@@ -1,13 +1,14 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "A Face feature: a bounded planar surface described by an outer Ring and optional inner (hole) Rings. geometry must be null. Each Ring uses directed_references to oriented Edge features.",
+  "description": "A Face feature: a bounded planar surface referencing Ring features via directed_references. geometry must be null.",
   "$defs": {
     "testCollection": {
       "$anchor": "testCollection",
-      "description": "A convienence ref to a complete, testable collection objects and references",
+      "description": "A convenience ref to a complete, testable collection objects and references",
       "$ref": "bblocks://ogc.geo.topo.features.topo-feature-collection"
     }
-  },  "allOf": [
+  },
+  "allOf": [
     {
       "$ref": "bblocks://ogc.geo.topo.features.topo-feature"
     },
@@ -16,30 +17,9 @@
         "geometry": { "type": "null" },
         "topology": {
           "properties": {
-            "type": { "type": "string", "const": "Face" },
-            "rings": {
-              "type": "array",
-              "description": "Ordered list of Ring topology objects. First ring is the outer boundary; any subsequent rings are inner boundaries (holes).",
-              "items": {
-                "type": "object",
-                "required": ["type", "directed_references"],
-                "properties": {
-                  "type": { "type": "string", "const": "Ring" },
-                  "directed_references": {
-                    "type": "array",
-                    "description": "Ordered oriented Edge references forming the ring boundary",
-                    "items": {
-                      "$ref": "bblocks://ogc.geo.topo.datatypes.oriented-ref"
-                    },
-                    "minItems": 3
-                  }
-                }
-              },
-              "minItems": 1
-            }
+            "type": { "type": "string", "const": "Face" }
           },
-          "required": ["type", "rings"],
-          "not": { "required": ["references", "directed_references"] }
+          "required": ["type", "directed_references"]
         }
       },
       "required": ["topology"]

--- a/_sources/features/topo-feature-collection/examples.yaml
+++ b/_sources/features/topo-feature-collection/examples.yaml
@@ -1,5 +1,6 @@
 - title: Example referenced points (no topology)
 
+  base-output-filename: points-only
   snippets:
     - language: json
       ref: examples/example-points.json
@@ -7,6 +8,7 @@
 
 - title: Example Lines
 
+  base-output-filename: referenced-points
   snippets:
     - language: json
       ref: examples/linestring.json
@@ -14,6 +16,7 @@
 
 - title: Points Lines and Polygons
 
+  base-output-filename: referenced-point-line-polygon
   snippets:
     - language: json
       ref: example.json

--- a/_sources/features/topo-feature-multi-collection/description.md
+++ b/_sources/features/topo-feature-multi-collection/description.md
@@ -1,34 +1,49 @@
 # Topo Feature Multi-Collection
 
-A **Topo Feature Multi-Collection** is a structured dataset that organises topological features into typed named collections, one for each topological dimension. This enables representation of a full topology hierarchy — from point nodes to volumetric solids — in a single, self-describing document.
+A **Topo Feature Multi-Collection** is a structured dataset that organises topological features into typed named collections, one for each topological dimension. 
+This enables representation of a full topology hierarchy — from point nodes to volumetric solids — in a single, self-describing document.
 
 ## Structure
 
-| Collection key | Feature type | Building block | Topology property |
-|---|---|---|---|
-| `points` | Point geometry nodes | GeoJSON Feature (Point geometry) | — (explicit coordinates) |
-| `edges` | Edge (line) topology | `topo-line` | `references`: ordered string IDs |
-| `faces` | Face (polygon surface) topology | `topo-face` | `rings[].directed_references`: oriented Edge refs |
-| `shells` | Shell (closed surface) topology | `topo-shell` | `directed_references`: oriented Face refs |
-| `solids` | Solid (volumetric) topology | `topo-feature` (Solid/Shell) | `shells[].directed_references`: oriented Face refs |
+| Collection key | Feature type                    | Building block                   | Topology property                                  |
+|----------------|---------------------------------|----------------------------------|----------------------------------------------------|
+| `points`       | Point geometry nodes            | GeoJSON Feature (Point geometry) | — (explicit coordinates)                           |
+| `edges`        | Edge (line) topology            | `topo-line`                      | `references`: ordered (string) point IDs           |
+| `rings`        | Ring (closed curve) topology    | `topo-ring`                      | `edge[].directed_references`: oriented Edge refs   |
+| `faces`        | Face (polygon surface) topology | `topo-face`                      | `rings[].directed_references`: oriented Ring refs  |
+| `shells`       | Shell (closed surface) topology | `topo-shell`                     | `face[].directed_references`: oriented Face refs   |
+| `solids`       | Solid (volumetric) topology     | `topo-feature` (Solid/Shell)     | `shells[].directed_references`: oriented Face refs |
 
 ## Reference models
 
 Two reference styles are used, each appropriate to the relationship type:
 
 - **`references`** — a plain ordered array of string feature IDs. Used for edges referencing point nodes, where position (not direction) is what matters.
-- **`directed_references`** — an ordered array of oriented object references `{ "ref": "...", "orientation": "+"|"-" }`. Used for Rings referencing Edges, and Shells referencing Faces, where traversal direction determines the sense of the boundary.
+- **`directed_references`** — an ordered array of oriented object references `{ "ref": "...", "orientation": "+"|"-" }`. 
+Used for Rings referencing Edges, Faces referencing Edges, Shells referencing Faces, and Solids referencing Shells, where traversal direction determines the sense of the boundary.
 
 The two styles must not coexist within the same topology object.
+
+Orientation is needed where the same primitive can be reused in opposite directions or on opposite sides of a higher-dimensional object. 
+A point has no direction, so an edge does not need to reference an “oriented point” in the same way that a ring references an oriented edge or a shell references an oriented face.
+Edges orientation is defined by an edges `startPoint` and `endPoint`. 
+
+Orientation is important because it defines which side of a face is inside or outside A solid.
+Shells bound a solid; shells are made from faces; faces are bounded by rings; rings use edges. 
+To know whether the solid is valid, closed, and consistently formed, it is important to understand which way each face is pointing.
+
+While for 2D polygons, orientation can be optional as exterior and interior boundaries can be readily identified. 
+For 3D solids orientation should be explicit, as interpreting unoriented 3D solids is harder and riskier because reversing a face can invert the local meaning of a solid boundary.
 
 ## Referential integrity chain
 
 ```
 solids
   └─ topology.shells[].directed_references → Face IDs
-       └─ topology.rings[].directed_references → Edge IDs
-            └─ topology.references → Point IDs
-                 └─ geometry.coordinates (actual 3D coordinates)
+       └─ topology.faces[].directed_references → Ring IDs
+            └─ topology.rings[].directed_references → Edge IDs   
+                └─ topology..edges[].references → Point IDs
+                    └─ points.geometry.coordinates (actual 3D coordinates)
 ```
 
 `geometry` is `null` on all feature types except Points — coordinates are derived by following the reference chain.
@@ -40,7 +55,9 @@ solids
   "type": "FeatureCollection",
   "points": [ { "type": "Feature", "geometry": { "type": "Point", "coordinates": [...] }, ... } ],
   "edges":  [ { "type": "Feature", "geometry": null, "topology": { "type": "Edge", "references": ["uuid:...", "uuid:..."] }, ... } ],
-  "faces":  [ { "type": "Feature", "geometry": null, "topology": { "type": "Face",   "rings": [{ "type": "Ring", "directed_references": [...] }] }, ... } ],
-  "solids": [ { "type": "Feature", "geometry": null, "topology": { "type": "Solid",  "shells": [{ "type": "Shell", "directed_references": [...] }] }, ... } ]
+  "rings":  [ { "type": "Feature", "geometry": null, "topology": { "type": "Ring", "directed_references": [{ "ref": "uuid:...", "orientation": "+" }, ... ] }, ... } ],
+  "faces":  [ { "type": "Feature", "geometry": null, "topology": { "type": "Face", "directed_references": [{ "ref": "uuid:...", "orientation": "+" }, ... ] }, ... } ],
+  "shells": [ { "type": "Feature", "geometry": null, "topology": { "type": "Shell", "directed_references": [{ "ref": "uuid:...", "orientation": "-" }, ... ] }, ... } ],
+  "solids": [ { "type": "Feature", "geometry": null, "topology": { "type": "Solid", "directed_references": [{ "ref": "uuid:...", "orientation": "+" }, ... ] }, ... } ]
 }
 ```

--- a/_sources/features/topo-feature-multi-collection/examples/cube-with-protrusion.json
+++ b/_sources/features/topo-feature-multi-collection/examples/cube-with-protrusion.json
@@ -27,7 +27,7 @@
     "foaf": "https://xmlns.com/foaf/0.1/",
     "activityType": "@type"
   },
-  "id": "uuid:65abe1ae-59bb-4fdd-82e8-8b24f263e743",
+  "id": "uuid:85702346-7889-4c90-88a8-81c0dde911ba",
   "name": "DP 12350",
   "description": "Cube with Protrusion test for Solid validation",
   "type": "FeatureCollection",
@@ -46,22 +46,22 @@
   "adminUnit": [],
   "hasProvenance": [],
   "wasGeneratedBy": {
-    "id": "uuid:f2a08a5e-16e7-40b8-b51e-a5692cf27949",
-    "endedAtTime": "2026-05-18T04:41:17.805303+00:00"
+    "id": "uuid:4315a17f-95c4-4f14-aafe-af668813c7aa",
+    "endedAtTime": "2026-05-19T03:52:52.191309+00:00"
   },
   "features": [],
   "referencedCSDs": [],
   "points": [
     {
-      "id": "uuid:fc3b042e-1160-4bfe-8d3a-fe523f90a6c5",
+      "id": "uuid:7a9002f6-8e9f-46ec-b0bd-302955bfbd38",
       "type": "FeatureCollection",
       "featureType": "CadastralMark",
       "features": [
         {
-          "id": "uuid:fba8e15d-9f2a-4b68-8e12-567728d164fe",
+          "id": "uuid:3f45a6c1-29b0-4440-8beb-170b96f2a9b6",
           "type": "Feature",
           "featureType": "BoundaryMark",
-          "time": "2026-05-18T04:41:17.802302+00:00",
+          "time": "2026-05-19T03:52:52.187308+00:00",
           "geometry": {
             "type": "Point",
             "coordinates": [
@@ -90,10 +90,10 @@
           }
         },
         {
-          "id": "uuid:dde7c070-c23a-4240-923f-6601f1b2bcd6",
+          "id": "uuid:bc2c9cb5-2a49-4335-a4d2-ec74be876177",
           "type": "Feature",
           "featureType": "BoundaryMark",
-          "time": "2026-05-18T04:41:17.802302+00:00",
+          "time": "2026-05-19T03:52:52.187308+00:00",
           "geometry": {
             "type": "Point",
             "coordinates": [
@@ -122,10 +122,10 @@
           }
         },
         {
-          "id": "uuid:1af22cd6-c241-4cd2-bdd5-e6e45ff0518f",
+          "id": "uuid:a3bf8f35-cf71-437e-b0ef-d21cb6b63593",
           "type": "Feature",
           "featureType": "BoundaryMark",
-          "time": "2026-05-18T04:41:17.802302+00:00",
+          "time": "2026-05-19T03:52:52.187308+00:00",
           "geometry": {
             "type": "Point",
             "coordinates": [
@@ -154,10 +154,10 @@
           }
         },
         {
-          "id": "uuid:4ac5232b-b2d2-432c-b047-7df2c3cb3c07",
+          "id": "uuid:57ed804e-51ef-4240-bc46-a9cc0f01562b",
           "type": "Feature",
           "featureType": "BoundaryMark",
-          "time": "2026-05-18T04:41:17.802302+00:00",
+          "time": "2026-05-19T03:52:52.187308+00:00",
           "geometry": {
             "type": "Point",
             "coordinates": [
@@ -186,10 +186,10 @@
           }
         },
         {
-          "id": "uuid:c9d13baf-25cc-4165-be0c-feb8382f6f5d",
+          "id": "uuid:060be32c-a4a5-4d41-b9a4-0ecdfe98c31a",
           "type": "Feature",
           "featureType": "BoundaryMark",
-          "time": "2026-05-18T04:41:17.802302+00:00",
+          "time": "2026-05-19T03:52:52.187308+00:00",
           "geometry": {
             "type": "Point",
             "coordinates": [
@@ -218,10 +218,10 @@
           }
         },
         {
-          "id": "uuid:00668ea1-fb8f-4f2a-a9c1-f4d4a13cd7d7",
+          "id": "uuid:8405e765-0540-4c14-8cee-662ffa1a8fbd",
           "type": "Feature",
           "featureType": "BoundaryMark",
-          "time": "2026-05-18T04:41:17.802302+00:00",
+          "time": "2026-05-19T03:52:52.187308+00:00",
           "geometry": {
             "type": "Point",
             "coordinates": [
@@ -250,10 +250,10 @@
           }
         },
         {
-          "id": "uuid:f638776d-4ad1-4798-913d-2792c08f0a5c",
+          "id": "uuid:98d4e171-bd19-44bd-ba29-7c46d1fae1ca",
           "type": "Feature",
           "featureType": "BoundaryMark",
-          "time": "2026-05-18T04:41:17.802302+00:00",
+          "time": "2026-05-19T03:52:52.187308+00:00",
           "geometry": {
             "type": "Point",
             "coordinates": [
@@ -282,10 +282,10 @@
           }
         },
         {
-          "id": "uuid:a1969f57-01b3-4f1c-917f-e1cc05efb502",
+          "id": "uuid:cfc8b55e-1745-4943-a559-7263a49b9568",
           "type": "Feature",
           "featureType": "BoundaryMark",
-          "time": "2026-05-18T04:41:17.802302+00:00",
+          "time": "2026-05-19T03:52:52.187308+00:00",
           "geometry": {
             "type": "Point",
             "coordinates": [
@@ -314,10 +314,10 @@
           }
         },
         {
-          "id": "uuid:62eed8d4-ef4a-4727-9cc3-f9701f796b86",
+          "id": "uuid:3cf453ea-d869-4bd7-b3da-c683276bba6f",
           "type": "Feature",
           "featureType": "BoundaryMark",
-          "time": "2026-05-18T04:41:17.802302+00:00",
+          "time": "2026-05-19T03:52:52.187308+00:00",
           "geometry": {
             "type": "Point",
             "coordinates": [
@@ -346,10 +346,10 @@
           }
         },
         {
-          "id": "uuid:5222db79-ba24-41c8-8661-0e37ca010924",
+          "id": "uuid:7dbd23f0-8173-4dfa-91f1-53129738520f",
           "type": "Feature",
           "featureType": "BoundaryMark",
-          "time": "2026-05-18T04:41:17.802302+00:00",
+          "time": "2026-05-19T03:52:52.187308+00:00",
           "geometry": {
             "type": "Point",
             "coordinates": [
@@ -378,10 +378,10 @@
           }
         },
         {
-          "id": "uuid:a1cadc18-0ede-4146-b5c6-f2094d3002d6",
+          "id": "uuid:a4f741a8-dcda-415c-80ec-2d5a7d84c368",
           "type": "Feature",
           "featureType": "BoundaryMark",
-          "time": "2026-05-18T04:41:17.802302+00:00",
+          "time": "2026-05-19T03:52:52.187308+00:00",
           "geometry": {
             "type": "Point",
             "coordinates": [
@@ -410,10 +410,10 @@
           }
         },
         {
-          "id": "uuid:af6ce8d8-a428-4f7c-8de5-4867cdf7882e",
+          "id": "uuid:7d6f1a6e-d89f-4505-a779-7b1ab044cb54",
           "type": "Feature",
           "featureType": "BoundaryMark",
-          "time": "2026-05-18T04:41:17.802302+00:00",
+          "time": "2026-05-19T03:52:52.187308+00:00",
           "geometry": {
             "type": "Point",
             "coordinates": [
@@ -442,10 +442,10 @@
           }
         },
         {
-          "id": "uuid:67e37eb9-ab2e-4c5e-abce-7ce1ca3acd14",
+          "id": "uuid:97e57f30-94e6-4871-8176-da926297232f",
           "type": "Feature",
           "featureType": "BoundaryMark",
-          "time": "2026-05-18T04:41:17.802302+00:00",
+          "time": "2026-05-19T03:52:52.187308+00:00",
           "geometry": {
             "type": "Point",
             "coordinates": [
@@ -474,10 +474,10 @@
           }
         },
         {
-          "id": "uuid:303d015d-e6c9-46f0-8dd9-1953ec5ca06c",
+          "id": "uuid:bbea1ffa-82a4-4c52-8e89-db5d4c7a0c25",
           "type": "Feature",
           "featureType": "BoundaryMark",
-          "time": "2026-05-18T04:41:17.802302+00:00",
+          "time": "2026-05-19T03:52:52.187308+00:00",
           "geometry": {
             "type": "Point",
             "coordinates": [
@@ -506,10 +506,10 @@
           }
         },
         {
-          "id": "uuid:c41396dd-24b4-4a99-9d29-2b793bdb3780",
+          "id": "uuid:ef3dcc76-513c-4043-980b-2764b7b341e4",
           "type": "Feature",
           "featureType": "BoundaryMark",
-          "time": "2026-05-18T04:41:17.802302+00:00",
+          "time": "2026-05-19T03:52:52.187308+00:00",
           "geometry": {
             "type": "Point",
             "coordinates": [
@@ -538,10 +538,10 @@
           }
         },
         {
-          "id": "uuid:1cd91836-ea95-438b-b67f-28c261c2f494",
+          "id": "uuid:7c8ac01f-1514-48ad-a6f3-6fcbe9c21d03",
           "type": "Feature",
           "featureType": "BoundaryMark",
-          "time": "2026-05-18T04:41:17.802302+00:00",
+          "time": "2026-05-19T03:52:52.187308+00:00",
           "geometry": {
             "type": "Point",
             "coordinates": [
@@ -577,19 +577,19 @@
   "parcels": [],
   "edges": [
     {
-      "id": "uuid:69dddf2b-c94e-4f0a-98c0-d83f622126ca",
+      "id": "uuid:a1cff144-27d7-46e8-9d19-2957c0d14193",
       "type": "FeatureCollection",
       "featureType": "Edge",
       "features": [
         {
-          "id": "uuid:ec64d4a3-dd60-4f9b-8336-b08c616ffcda",
+          "id": "uuid:4de72a54-dc6e-453b-8679-f640004b3fb9",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Edge",
             "references": [
-              "uuid:fba8e15d-9f2a-4b68-8e12-567728d164fe",
-              "uuid:dde7c070-c23a-4240-923f-6601f1b2bcd6"
+              "uuid:3f45a6c1-29b0-4440-8beb-170b96f2a9b6",
+              "uuid:bc2c9cb5-2a49-4335-a4d2-ec74be876177"
             ]
           },
           "properties": {
@@ -599,14 +599,14 @@
           }
         },
         {
-          "id": "uuid:2a432f54-75a3-4921-80fd-57460d162e21",
+          "id": "uuid:2b07a965-fe9b-4500-ae99-8d577b091b51",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Edge",
             "references": [
-              "uuid:dde7c070-c23a-4240-923f-6601f1b2bcd6",
-              "uuid:1af22cd6-c241-4cd2-bdd5-e6e45ff0518f"
+              "uuid:bc2c9cb5-2a49-4335-a4d2-ec74be876177",
+              "uuid:a3bf8f35-cf71-437e-b0ef-d21cb6b63593"
             ]
           },
           "properties": {
@@ -616,14 +616,14 @@
           }
         },
         {
-          "id": "uuid:a1fddc15-2a57-416f-b5d7-45e78b496dae",
+          "id": "uuid:69eeb511-0d06-4dbd-83d9-329bfbf4430c",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Edge",
             "references": [
-              "uuid:1af22cd6-c241-4cd2-bdd5-e6e45ff0518f",
-              "uuid:4ac5232b-b2d2-432c-b047-7df2c3cb3c07"
+              "uuid:a3bf8f35-cf71-437e-b0ef-d21cb6b63593",
+              "uuid:57ed804e-51ef-4240-bc46-a9cc0f01562b"
             ]
           },
           "properties": {
@@ -633,14 +633,14 @@
           }
         },
         {
-          "id": "uuid:3e360965-27fe-4850-b435-f5421bcce1b3",
+          "id": "uuid:2c406787-a710-4ca2-a39f-487a9ac31bfc",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Edge",
             "references": [
-              "uuid:4ac5232b-b2d2-432c-b047-7df2c3cb3c07",
-              "uuid:fba8e15d-9f2a-4b68-8e12-567728d164fe"
+              "uuid:57ed804e-51ef-4240-bc46-a9cc0f01562b",
+              "uuid:3f45a6c1-29b0-4440-8beb-170b96f2a9b6"
             ]
           },
           "properties": {
@@ -650,14 +650,14 @@
           }
         },
         {
-          "id": "uuid:e7fc710e-1cef-462e-ba2d-a95a72857ce5",
+          "id": "uuid:569b7961-5cd8-4c15-9d78-897da56085b2",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Edge",
             "references": [
-              "uuid:c9d13baf-25cc-4165-be0c-feb8382f6f5d",
-              "uuid:fba8e15d-9f2a-4b68-8e12-567728d164fe"
+              "uuid:060be32c-a4a5-4d41-b9a4-0ecdfe98c31a",
+              "uuid:3f45a6c1-29b0-4440-8beb-170b96f2a9b6"
             ]
           },
           "properties": {
@@ -667,14 +667,14 @@
           }
         },
         {
-          "id": "uuid:25e122a6-a42f-4fcf-9ba2-4b6d8cac4c16",
+          "id": "uuid:14e9e034-a3a4-4426-8e48-14d0ba5b4839",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Edge",
             "references": [
-              "uuid:4ac5232b-b2d2-432c-b047-7df2c3cb3c07",
-              "uuid:00668ea1-fb8f-4f2a-a9c1-f4d4a13cd7d7"
+              "uuid:57ed804e-51ef-4240-bc46-a9cc0f01562b",
+              "uuid:8405e765-0540-4c14-8cee-662ffa1a8fbd"
             ]
           },
           "properties": {
@@ -684,14 +684,14 @@
           }
         },
         {
-          "id": "uuid:b8b43183-1e70-4972-b867-625897b10867",
+          "id": "uuid:6c6b25f1-6a58-4995-8e9d-136a4c313ffa",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Edge",
             "references": [
-              "uuid:00668ea1-fb8f-4f2a-a9c1-f4d4a13cd7d7",
-              "uuid:c9d13baf-25cc-4165-be0c-feb8382f6f5d"
+              "uuid:8405e765-0540-4c14-8cee-662ffa1a8fbd",
+              "uuid:060be32c-a4a5-4d41-b9a4-0ecdfe98c31a"
             ]
           },
           "properties": {
@@ -701,14 +701,14 @@
           }
         },
         {
-          "id": "uuid:d05095be-3eb9-405d-a456-424180bbdbfd",
+          "id": "uuid:8b738339-47ba-4e2f-941c-0b11e851343c",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Edge",
             "references": [
-              "uuid:f638776d-4ad1-4798-913d-2792c08f0a5c",
-              "uuid:c9d13baf-25cc-4165-be0c-feb8382f6f5d"
+              "uuid:98d4e171-bd19-44bd-ba29-7c46d1fae1ca",
+              "uuid:060be32c-a4a5-4d41-b9a4-0ecdfe98c31a"
             ]
           },
           "properties": {
@@ -718,14 +718,14 @@
           }
         },
         {
-          "id": "uuid:da652fb9-5d0b-4edc-9b2b-9d34c7c705c0",
+          "id": "uuid:6050a59e-4f96-44c8-af20-8fe4ab73b1af",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Edge",
             "references": [
-              "uuid:00668ea1-fb8f-4f2a-a9c1-f4d4a13cd7d7",
-              "uuid:a1969f57-01b3-4f1c-917f-e1cc05efb502"
+              "uuid:8405e765-0540-4c14-8cee-662ffa1a8fbd",
+              "uuid:cfc8b55e-1745-4943-a559-7263a49b9568"
             ]
           },
           "properties": {
@@ -735,14 +735,14 @@
           }
         },
         {
-          "id": "uuid:66609f1f-21a9-4041-9068-cca1a38d9460",
+          "id": "uuid:7a074a74-690b-4ca8-97b7-78b328a0651d",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Edge",
             "references": [
-              "uuid:a1969f57-01b3-4f1c-917f-e1cc05efb502",
-              "uuid:f638776d-4ad1-4798-913d-2792c08f0a5c"
+              "uuid:cfc8b55e-1745-4943-a559-7263a49b9568",
+              "uuid:98d4e171-bd19-44bd-ba29-7c46d1fae1ca"
             ]
           },
           "properties": {
@@ -752,14 +752,14 @@
           }
         },
         {
-          "id": "uuid:e7e434cb-2492-4e3d-a77e-3b587dfeb89a",
+          "id": "uuid:848720a5-5a41-488d-ab8a-24e944b422fe",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Edge",
             "references": [
-              "uuid:62eed8d4-ef4a-4727-9cc3-f9701f796b86",
-              "uuid:5222db79-ba24-41c8-8661-0e37ca010924"
+              "uuid:3cf453ea-d869-4bd7-b3da-c683276bba6f",
+              "uuid:7dbd23f0-8173-4dfa-91f1-53129738520f"
             ]
           },
           "properties": {
@@ -769,14 +769,14 @@
           }
         },
         {
-          "id": "uuid:187a71f4-78b5-4590-a505-ac9f1893c8b8",
+          "id": "uuid:79af8c69-fbc0-4aea-9756-ebbb1184de61",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Edge",
             "references": [
-              "uuid:a1cadc18-0ede-4146-b5c6-f2094d3002d6",
-              "uuid:62eed8d4-ef4a-4727-9cc3-f9701f796b86"
+              "uuid:a4f741a8-dcda-415c-80ec-2d5a7d84c368",
+              "uuid:3cf453ea-d869-4bd7-b3da-c683276bba6f"
             ]
           },
           "properties": {
@@ -786,14 +786,14 @@
           }
         },
         {
-          "id": "uuid:f18f9ce4-3ba9-412e-bd63-05ec6c9c808d",
+          "id": "uuid:a7bf25eb-0ba4-4a7a-830e-0203fef8bc9c",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Edge",
             "references": [
-              "uuid:af6ce8d8-a428-4f7c-8de5-4867cdf7882e",
-              "uuid:a1cadc18-0ede-4146-b5c6-f2094d3002d6"
+              "uuid:7d6f1a6e-d89f-4505-a779-7b1ab044cb54",
+              "uuid:a4f741a8-dcda-415c-80ec-2d5a7d84c368"
             ]
           },
           "properties": {
@@ -803,14 +803,14 @@
           }
         },
         {
-          "id": "uuid:0d971cf7-3ca5-48a4-86a2-7fcd094f3866",
+          "id": "uuid:da372a4b-04a9-4960-bc1f-c1e63ca5baff",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Edge",
             "references": [
-              "uuid:5222db79-ba24-41c8-8661-0e37ca010924",
-              "uuid:af6ce8d8-a428-4f7c-8de5-4867cdf7882e"
+              "uuid:7dbd23f0-8173-4dfa-91f1-53129738520f",
+              "uuid:7d6f1a6e-d89f-4505-a779-7b1ab044cb54"
             ]
           },
           "properties": {
@@ -820,14 +820,14 @@
           }
         },
         {
-          "id": "uuid:2992bb6a-8ec5-4224-a1e8-ea28a5585913",
+          "id": "uuid:4057e37e-7772-4407-9af6-6106a7ce3357",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Edge",
             "references": [
-              "uuid:a1cadc18-0ede-4146-b5c6-f2094d3002d6",
-              "uuid:67e37eb9-ab2e-4c5e-abce-7ce1ca3acd14"
+              "uuid:a4f741a8-dcda-415c-80ec-2d5a7d84c368",
+              "uuid:97e57f30-94e6-4871-8176-da926297232f"
             ]
           },
           "properties": {
@@ -837,14 +837,14 @@
           }
         },
         {
-          "id": "uuid:df7143d2-41f4-4252-8d6b-9fd0ee24088b",
+          "id": "uuid:230661f6-40b6-4038-a892-c21cdc65a441",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Edge",
             "references": [
-              "uuid:67e37eb9-ab2e-4c5e-abce-7ce1ca3acd14",
-              "uuid:303d015d-e6c9-46f0-8dd9-1953ec5ca06c"
+              "uuid:97e57f30-94e6-4871-8176-da926297232f",
+              "uuid:bbea1ffa-82a4-4c52-8e89-db5d4c7a0c25"
             ]
           },
           "properties": {
@@ -854,14 +854,14 @@
           }
         },
         {
-          "id": "uuid:4f742e96-9fdb-4782-b3c9-411991c3c7e6",
+          "id": "uuid:afabe16a-2949-435c-9660-9a6b1d76975f",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Edge",
             "references": [
-              "uuid:303d015d-e6c9-46f0-8dd9-1953ec5ca06c",
-              "uuid:af6ce8d8-a428-4f7c-8de5-4867cdf7882e"
+              "uuid:bbea1ffa-82a4-4c52-8e89-db5d4c7a0c25",
+              "uuid:7d6f1a6e-d89f-4505-a779-7b1ab044cb54"
             ]
           },
           "properties": {
@@ -871,14 +871,14 @@
           }
         },
         {
-          "id": "uuid:5ee50574-216d-4db3-a8dc-03475bbea27c",
+          "id": "uuid:87c95736-4b67-4a77-8e60-76a309d9ea3d",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Edge",
             "references": [
-              "uuid:62eed8d4-ef4a-4727-9cc3-f9701f796b86",
-              "uuid:c41396dd-24b4-4a99-9d29-2b793bdb3780"
+              "uuid:3cf453ea-d869-4bd7-b3da-c683276bba6f",
+              "uuid:ef3dcc76-513c-4043-980b-2764b7b341e4"
             ]
           },
           "properties": {
@@ -888,14 +888,14 @@
           }
         },
         {
-          "id": "uuid:8b026a49-a942-4c60-b6f9-1eec9a9e2785",
+          "id": "uuid:73e00170-a8d8-4cad-8c93-75e99303786a",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Edge",
             "references": [
-              "uuid:c41396dd-24b4-4a99-9d29-2b793bdb3780",
-              "uuid:67e37eb9-ab2e-4c5e-abce-7ce1ca3acd14"
+              "uuid:ef3dcc76-513c-4043-980b-2764b7b341e4",
+              "uuid:97e57f30-94e6-4871-8176-da926297232f"
             ]
           },
           "properties": {
@@ -905,14 +905,14 @@
           }
         },
         {
-          "id": "uuid:e2736602-61f2-467f-b050-e0a1047474af",
+          "id": "uuid:4581a51b-5bd6-4b58-bc40-91ae85534046",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Edge",
             "references": [
-              "uuid:5222db79-ba24-41c8-8661-0e37ca010924",
-              "uuid:1cd91836-ea95-438b-b67f-28c261c2f494"
+              "uuid:7dbd23f0-8173-4dfa-91f1-53129738520f",
+              "uuid:7c8ac01f-1514-48ad-a6f3-6fcbe9c21d03"
             ]
           },
           "properties": {
@@ -922,14 +922,14 @@
           }
         },
         {
-          "id": "uuid:b6a97f35-fbf7-43aa-b98f-4d117c5ce393",
+          "id": "uuid:60d9a7e8-5511-4f8f-a4d8-1609abb15d8b",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Edge",
             "references": [
-              "uuid:1cd91836-ea95-438b-b67f-28c261c2f494",
-              "uuid:c41396dd-24b4-4a99-9d29-2b793bdb3780"
+              "uuid:7c8ac01f-1514-48ad-a6f3-6fcbe9c21d03",
+              "uuid:ef3dcc76-513c-4043-980b-2764b7b341e4"
             ]
           },
           "properties": {
@@ -939,14 +939,14 @@
           }
         },
         {
-          "id": "uuid:c6c71c92-9daf-41a5-a2ab-c1b63166d658",
+          "id": "uuid:969851a7-72b3-406d-9d92-8e7cdd157b2f",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Edge",
             "references": [
-              "uuid:303d015d-e6c9-46f0-8dd9-1953ec5ca06c",
-              "uuid:1cd91836-ea95-438b-b67f-28c261c2f494"
+              "uuid:bbea1ffa-82a4-4c52-8e89-db5d4c7a0c25",
+              "uuid:7c8ac01f-1514-48ad-a6f3-6fcbe9c21d03"
             ]
           },
           "properties": {
@@ -956,14 +956,14 @@
           }
         },
         {
-          "id": "uuid:b4ea9b84-0468-4eea-8200-20ab2000692c",
+          "id": "uuid:c5c2dcdb-3f69-45d0-90d6-0f08ad71c7e6",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Edge",
             "references": [
-              "uuid:dde7c070-c23a-4240-923f-6601f1b2bcd6",
-              "uuid:f638776d-4ad1-4798-913d-2792c08f0a5c"
+              "uuid:bc2c9cb5-2a49-4335-a4d2-ec74be876177",
+              "uuid:98d4e171-bd19-44bd-ba29-7c46d1fae1ca"
             ]
           },
           "properties": {
@@ -973,14 +973,14 @@
           }
         },
         {
-          "id": "uuid:2e7af4a9-949d-45d9-a3fd-35c4b24baffb",
+          "id": "uuid:28b19e75-23cb-4c72-ae42-0839b7f39e27",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Edge",
             "references": [
-              "uuid:a1969f57-01b3-4f1c-917f-e1cc05efb502",
-              "uuid:1af22cd6-c241-4cd2-bdd5-e6e45ff0518f"
+              "uuid:cfc8b55e-1745-4943-a559-7263a49b9568",
+              "uuid:a3bf8f35-cf71-437e-b0ef-d21cb6b63593"
             ]
           },
           "properties": {
@@ -994,31 +994,31 @@
   ],
   "rings": [
     {
-      "id": "uuid:e089fff6-3d26-450f-a188-139728de7269",
+      "id": "uuid:394e96e4-c335-49f4-916b-47593774cb5b",
       "type": "FeatureCollection",
       "featureType": "Ring",
       "features": [
         {
-          "id": "uuid:d16e4e15-55b5-47c3-b137-8a80665327eb",
+          "id": "uuid:c9547610-3aea-4af5-ba1c-99411fab12d6",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Ring",
             "directed_references": [
               {
-                "ref": "uuid:ec64d4a3-dd60-4f9b-8336-b08c616ffcda",
+                "ref": "uuid:4de72a54-dc6e-453b-8679-f640004b3fb9",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:2a432f54-75a3-4921-80fd-57460d162e21",
+                "ref": "uuid:2b07a965-fe9b-4500-ae99-8d577b091b51",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:a1fddc15-2a57-416f-b5d7-45e78b496dae",
+                "ref": "uuid:69eeb511-0d06-4dbd-83d9-329bfbf4430c",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:3e360965-27fe-4850-b435-f5421bcce1b3",
+                "ref": "uuid:2c406787-a710-4ca2-a39f-487a9ac31bfc",
                 "orientation": "+"
               }
             ]
@@ -1028,26 +1028,26 @@
           }
         },
         {
-          "id": "uuid:354e89e5-7f63-405d-b314-f546d7bd1720",
+          "id": "uuid:b03457ab-1cbf-46ee-bc54-9778eada63d6",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Ring",
             "directed_references": [
               {
-                "ref": "uuid:e7fc710e-1cef-462e-ba2d-a95a72857ce5",
+                "ref": "uuid:569b7961-5cd8-4c15-9d78-897da56085b2",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:3e360965-27fe-4850-b435-f5421bcce1b3",
+                "ref": "uuid:2c406787-a710-4ca2-a39f-487a9ac31bfc",
                 "orientation": "-"
               },
               {
-                "ref": "uuid:25e122a6-a42f-4fcf-9ba2-4b6d8cac4c16",
+                "ref": "uuid:14e9e034-a3a4-4426-8e48-14d0ba5b4839",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:b8b43183-1e70-4972-b867-625897b10867",
+                "ref": "uuid:6c6b25f1-6a58-4995-8e9d-136a4c313ffa",
                 "orientation": "+"
               }
             ]
@@ -1057,26 +1057,26 @@
           }
         },
         {
-          "id": "uuid:5a103c10-44de-4942-a362-77c11bce375a",
+          "id": "uuid:8371609e-f12a-450b-8d72-119378d4e90c",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Ring",
             "directed_references": [
               {
-                "ref": "uuid:d05095be-3eb9-405d-a456-424180bbdbfd",
+                "ref": "uuid:8b738339-47ba-4e2f-941c-0b11e851343c",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:b8b43183-1e70-4972-b867-625897b10867",
+                "ref": "uuid:6c6b25f1-6a58-4995-8e9d-136a4c313ffa",
                 "orientation": "-"
               },
               {
-                "ref": "uuid:da652fb9-5d0b-4edc-9b2b-9d34c7c705c0",
+                "ref": "uuid:6050a59e-4f96-44c8-af20-8fe4ab73b1af",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:66609f1f-21a9-4041-9068-cca1a38d9460",
+                "ref": "uuid:7a074a74-690b-4ca8-97b7-78b328a0651d",
                 "orientation": "+"
               }
             ]
@@ -1086,26 +1086,26 @@
           }
         },
         {
-          "id": "uuid:133660ca-1a23-472b-a39f-76c6bf12655d",
+          "id": "uuid:1fafe839-6460-4cd6-8f9c-451005384804",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Ring",
             "directed_references": [
               {
-                "ref": "uuid:e7e434cb-2492-4e3d-a77e-3b587dfeb89a",
+                "ref": "uuid:848720a5-5a41-488d-ab8a-24e944b422fe",
                 "orientation": "-"
               },
               {
-                "ref": "uuid:187a71f4-78b5-4590-a505-ac9f1893c8b8",
+                "ref": "uuid:79af8c69-fbc0-4aea-9756-ebbb1184de61",
                 "orientation": "-"
               },
               {
-                "ref": "uuid:f18f9ce4-3ba9-412e-bd63-05ec6c9c808d",
+                "ref": "uuid:a7bf25eb-0ba4-4a7a-830e-0203fef8bc9c",
                 "orientation": "-"
               },
               {
-                "ref": "uuid:0d971cf7-3ca5-48a4-86a2-7fcd094f3866",
+                "ref": "uuid:da372a4b-04a9-4960-bc1f-c1e63ca5baff",
                 "orientation": "-"
               }
             ]
@@ -1115,26 +1115,26 @@
           }
         },
         {
-          "id": "uuid:934d0add-3f15-493c-94c1-bd8b135ece56",
+          "id": "uuid:0451532d-168c-4f08-83cc-d94629b744a7",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Ring",
             "directed_references": [
               {
-                "ref": "uuid:f18f9ce4-3ba9-412e-bd63-05ec6c9c808d",
+                "ref": "uuid:a7bf25eb-0ba4-4a7a-830e-0203fef8bc9c",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:2992bb6a-8ec5-4224-a1e8-ea28a5585913",
+                "ref": "uuid:4057e37e-7772-4407-9af6-6106a7ce3357",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:df7143d2-41f4-4252-8d6b-9fd0ee24088b",
+                "ref": "uuid:230661f6-40b6-4038-a892-c21cdc65a441",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:4f742e96-9fdb-4782-b3c9-411991c3c7e6",
+                "ref": "uuid:afabe16a-2949-435c-9660-9a6b1d76975f",
                 "orientation": "+"
               }
             ]
@@ -1144,26 +1144,26 @@
           }
         },
         {
-          "id": "uuid:c47bf67e-102e-44d1-ab1b-428782d644cc",
+          "id": "uuid:8c7b5e4d-3b96-4dcf-8b35-44ea0e434206",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Ring",
             "directed_references": [
               {
-                "ref": "uuid:187a71f4-78b5-4590-a505-ac9f1893c8b8",
+                "ref": "uuid:79af8c69-fbc0-4aea-9756-ebbb1184de61",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:5ee50574-216d-4db3-a8dc-03475bbea27c",
+                "ref": "uuid:87c95736-4b67-4a77-8e60-76a309d9ea3d",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:8b026a49-a942-4c60-b6f9-1eec9a9e2785",
+                "ref": "uuid:73e00170-a8d8-4cad-8c93-75e99303786a",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:2992bb6a-8ec5-4224-a1e8-ea28a5585913",
+                "ref": "uuid:4057e37e-7772-4407-9af6-6106a7ce3357",
                 "orientation": "-"
               }
             ]
@@ -1173,26 +1173,26 @@
           }
         },
         {
-          "id": "uuid:425efe55-9931-4e31-a60c-6db08cb25e8a",
+          "id": "uuid:9558f5c8-06f7-44ba-bf0b-907bc441ef83",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Ring",
             "directed_references": [
               {
-                "ref": "uuid:e7e434cb-2492-4e3d-a77e-3b587dfeb89a",
+                "ref": "uuid:848720a5-5a41-488d-ab8a-24e944b422fe",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:e2736602-61f2-467f-b050-e0a1047474af",
+                "ref": "uuid:4581a51b-5bd6-4b58-bc40-91ae85534046",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:b6a97f35-fbf7-43aa-b98f-4d117c5ce393",
+                "ref": "uuid:60d9a7e8-5511-4f8f-a4d8-1609abb15d8b",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:5ee50574-216d-4db3-a8dc-03475bbea27c",
+                "ref": "uuid:87c95736-4b67-4a77-8e60-76a309d9ea3d",
                 "orientation": "-"
               }
             ]
@@ -1202,26 +1202,26 @@
           }
         },
         {
-          "id": "uuid:6405a69a-a313-4334-982b-7af7b9b6e8e0",
+          "id": "uuid:35c56557-1373-4357-9002-44898436268f",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Ring",
             "directed_references": [
               {
-                "ref": "uuid:0d971cf7-3ca5-48a4-86a2-7fcd094f3866",
+                "ref": "uuid:da372a4b-04a9-4960-bc1f-c1e63ca5baff",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:4f742e96-9fdb-4782-b3c9-411991c3c7e6",
+                "ref": "uuid:afabe16a-2949-435c-9660-9a6b1d76975f",
                 "orientation": "-"
               },
               {
-                "ref": "uuid:c6c71c92-9daf-41a5-a2ab-c1b63166d658",
+                "ref": "uuid:969851a7-72b3-406d-9d92-8e7cdd157b2f",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:e2736602-61f2-467f-b050-e0a1047474af",
+                "ref": "uuid:4581a51b-5bd6-4b58-bc40-91ae85534046",
                 "orientation": "-"
               }
             ]
@@ -1231,26 +1231,26 @@
           }
         },
         {
-          "id": "uuid:e9c44d08-5810-4481-a843-a2a15ababe59",
+          "id": "uuid:8073b1ec-1831-4de2-84a3-81ee0f115674",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Ring",
             "directed_references": [
               {
-                "ref": "uuid:b4ea9b84-0468-4eea-8200-20ab2000692c",
+                "ref": "uuid:c5c2dcdb-3f69-45d0-90d6-0f08ad71c7e6",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:66609f1f-21a9-4041-9068-cca1a38d9460",
+                "ref": "uuid:7a074a74-690b-4ca8-97b7-78b328a0651d",
                 "orientation": "-"
               },
               {
-                "ref": "uuid:2e7af4a9-949d-45d9-a3fd-35c4b24baffb",
+                "ref": "uuid:28b19e75-23cb-4c72-ae42-0839b7f39e27",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:2a432f54-75a3-4921-80fd-57460d162e21",
+                "ref": "uuid:2b07a965-fe9b-4500-ae99-8d577b091b51",
                 "orientation": "-"
               }
             ]
@@ -1260,26 +1260,26 @@
           }
         },
         {
-          "id": "uuid:feaa1540-b6ef-46c7-93c7-9db0e20039d0",
+          "id": "uuid:f9ccef4f-1d39-4430-8ba3-4fb7ebd1c528",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Ring",
             "directed_references": [
               {
-                "ref": "uuid:25e122a6-a42f-4fcf-9ba2-4b6d8cac4c16",
+                "ref": "uuid:14e9e034-a3a4-4426-8e48-14d0ba5b4839",
                 "orientation": "-"
               },
               {
-                "ref": "uuid:a1fddc15-2a57-416f-b5d7-45e78b496dae",
+                "ref": "uuid:69eeb511-0d06-4dbd-83d9-329bfbf4430c",
                 "orientation": "-"
               },
               {
-                "ref": "uuid:2e7af4a9-949d-45d9-a3fd-35c4b24baffb",
+                "ref": "uuid:28b19e75-23cb-4c72-ae42-0839b7f39e27",
                 "orientation": "-"
               },
               {
-                "ref": "uuid:da652fb9-5d0b-4edc-9b2b-9d34c7c705c0",
+                "ref": "uuid:6050a59e-4f96-44c8-af20-8fe4ab73b1af",
                 "orientation": "-"
               }
             ]
@@ -1289,26 +1289,26 @@
           }
         },
         {
-          "id": "uuid:096e1016-ef94-4942-a234-c2b0735f3568",
+          "id": "uuid:e0452825-9a9e-4422-a3fa-21ee220c5d40",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Ring",
             "directed_references": [
               {
-                "ref": "uuid:e7fc710e-1cef-462e-ba2d-a95a72857ce5",
+                "ref": "uuid:569b7961-5cd8-4c15-9d78-897da56085b2",
                 "orientation": "-"
               },
               {
-                "ref": "uuid:d05095be-3eb9-405d-a456-424180bbdbfd",
+                "ref": "uuid:8b738339-47ba-4e2f-941c-0b11e851343c",
                 "orientation": "-"
               },
               {
-                "ref": "uuid:b4ea9b84-0468-4eea-8200-20ab2000692c",
+                "ref": "uuid:c5c2dcdb-3f69-45d0-90d6-0f08ad71c7e6",
                 "orientation": "-"
               },
               {
-                "ref": "uuid:ec64d4a3-dd60-4f9b-8336-b08c616ffcda",
+                "ref": "uuid:4de72a54-dc6e-453b-8679-f640004b3fb9",
                 "orientation": "-"
               }
             ]
@@ -1318,26 +1318,26 @@
           }
         },
         {
-          "id": "uuid:ee5d0c3a-7f69-4b1d-817e-06a0c8f837f0",
+          "id": "uuid:7bc386a9-a7de-470d-98b2-85d0db96788d",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Ring",
             "directed_references": [
               {
-                "ref": "uuid:b6a97f35-fbf7-43aa-b98f-4d117c5ce393",
+                "ref": "uuid:60d9a7e8-5511-4f8f-a4d8-1609abb15d8b",
                 "orientation": "-"
               },
               {
-                "ref": "uuid:c6c71c92-9daf-41a5-a2ab-c1b63166d658",
+                "ref": "uuid:969851a7-72b3-406d-9d92-8e7cdd157b2f",
                 "orientation": "-"
               },
               {
-                "ref": "uuid:df7143d2-41f4-4252-8d6b-9fd0ee24088b",
+                "ref": "uuid:230661f6-40b6-4038-a892-c21cdc65a441",
                 "orientation": "-"
               },
               {
-                "ref": "uuid:8b026a49-a942-4c60-b6f9-1eec9a9e2785",
+                "ref": "uuid:73e00170-a8d8-4cad-8c93-75e99303786a",
                 "orientation": "-"
               }
             ]
@@ -1351,19 +1351,19 @@
   ],
   "faces": [
     {
-      "id": "uuid:5e42ed7a-a9da-44bb-86fe-0cc1feff1f3d",
+      "id": "uuid:a78b491a-9cf9-4dc8-b195-519601b38cff",
       "type": "FeatureCollection",
       "featureType": "Face",
       "features": [
         {
-          "id": "uuid:29ecec10-c621-4873-ab17-a45cb95ee321",
+          "id": "uuid:2ca00a69-cccb-408f-924a-8cb54ddb9fe8",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Face",
             "directed_references": [
               {
-                "ref": "uuid:d16e4e15-55b5-47c3-b137-8a80665327eb",
+                "ref": "uuid:c9547610-3aea-4af5-ba1c-99411fab12d6",
                 "orientation": "+"
               }
             ]
@@ -1379,14 +1379,14 @@
           }
         },
         {
-          "id": "uuid:f8aa06c7-3c40-4dd9-a029-0b67a4fa0280",
+          "id": "uuid:88fedfec-2cb7-41f7-8948-dc5a5a2ecf55",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Face",
             "directed_references": [
               {
-                "ref": "uuid:354e89e5-7f63-405d-b314-f546d7bd1720",
+                "ref": "uuid:b03457ab-1cbf-46ee-bc54-9778eada63d6",
                 "orientation": "+"
               }
             ]
@@ -1402,18 +1402,18 @@
           }
         },
         {
-          "id": "uuid:abedfbd9-9637-4c78-acba-9dc9df413b24",
+          "id": "uuid:3b3cd92a-5778-408d-8b6f-04b390c7f6fc",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Face",
             "directed_references": [
               {
-                "ref": "uuid:5a103c10-44de-4942-a362-77c11bce375a",
+                "ref": "uuid:8371609e-f12a-450b-8d72-119378d4e90c",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:133660ca-1a23-472b-a39f-76c6bf12655d",
+                "ref": "uuid:1fafe839-6460-4cd6-8f9c-451005384804",
                 "orientation": "+"
               }
             ]
@@ -1424,19 +1424,19 @@
               2.166134286404929e-06,
               1.5653513048356715e-06
             ],
-            "area": 47.982,
+            "area": 63.982,
             "description": "East-facing boundary face, [Cube with Protrusion]"
           }
         },
         {
-          "id": "uuid:9784caee-d2dd-4908-9204-14a4280bd726",
+          "id": "uuid:4f371f0a-c9e0-4f4e-bdcc-d74d495b434f",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Face",
             "directed_references": [
               {
-                "ref": "uuid:934d0add-3f15-493c-94c1-bd8b135ece56",
+                "ref": "uuid:0451532d-168c-4f08-83cc-d94629b744a7",
                 "orientation": "+"
               }
             ]
@@ -1452,14 +1452,14 @@
           }
         },
         {
-          "id": "uuid:8ac99859-4d85-41e6-a842-0fc7aebec301",
+          "id": "uuid:113f902b-349b-4e42-98ac-65dc5bfc1e8d",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Face",
             "directed_references": [
               {
-                "ref": "uuid:c47bf67e-102e-44d1-ab1b-428782d644cc",
+                "ref": "uuid:8c7b5e4d-3b96-4dcf-8b35-44ea0e434206",
                 "orientation": "+"
               }
             ]
@@ -1475,14 +1475,14 @@
           }
         },
         {
-          "id": "uuid:472defbe-a781-4b74-8265-5d5cabab5582",
+          "id": "uuid:b4afb1e1-8688-4be8-9e58-e0fe573ba896",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Face",
             "directed_references": [
               {
-                "ref": "uuid:425efe55-9931-4e31-a60c-6db08cb25e8a",
+                "ref": "uuid:9558f5c8-06f7-44ba-bf0b-907bc441ef83",
                 "orientation": "+"
               }
             ]
@@ -1498,14 +1498,14 @@
           }
         },
         {
-          "id": "uuid:d4211a73-0d4b-432d-851d-82c42977ae91",
+          "id": "uuid:e67afa7f-cf0c-4201-a066-9c5a23a961fa",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Face",
             "directed_references": [
               {
-                "ref": "uuid:6405a69a-a313-4334-982b-7af7b9b6e8e0",
+                "ref": "uuid:35c56557-1373-4357-9002-44898436268f",
                 "orientation": "+"
               }
             ]
@@ -1521,14 +1521,14 @@
           }
         },
         {
-          "id": "uuid:55e9c1cc-0f84-47c9-af2d-97cd017ee0fc",
+          "id": "uuid:c8d5a816-1012-40de-b696-aacf763e9be4",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Face",
             "directed_references": [
               {
-                "ref": "uuid:e9c44d08-5810-4481-a843-a2a15ababe59",
+                "ref": "uuid:8073b1ec-1831-4de2-84a3-81ee0f115674",
                 "orientation": "+"
               }
             ]
@@ -1544,14 +1544,14 @@
           }
         },
         {
-          "id": "uuid:40fde941-9b67-4d4e-9922-051db969d587",
+          "id": "uuid:da87be42-6980-4503-925d-a61b27eded57",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Face",
             "directed_references": [
               {
-                "ref": "uuid:feaa1540-b6ef-46c7-93c7-9db0e20039d0",
+                "ref": "uuid:f9ccef4f-1d39-4430-8ba3-4fb7ebd1c528",
                 "orientation": "+"
               }
             ]
@@ -1567,14 +1567,14 @@
           }
         },
         {
-          "id": "uuid:f1dafb5b-606d-412b-993d-8da6ce2a39e6",
+          "id": "uuid:5c11a64f-3b16-45b1-97b5-23e825d38402",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Face",
             "directed_references": [
               {
-                "ref": "uuid:096e1016-ef94-4942-a234-c2b0735f3568",
+                "ref": "uuid:e0452825-9a9e-4422-a3fa-21ee220c5d40",
                 "orientation": "+"
               }
             ]
@@ -1590,14 +1590,14 @@
           }
         },
         {
-          "id": "uuid:6790c7df-a754-49ca-b45a-8c70b8fe409d",
+          "id": "uuid:1de8896f-a293-4c4b-90f6-3670fe0cd761",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Face",
             "directed_references": [
               {
-                "ref": "uuid:ee5d0c3a-7f69-4b1d-817e-06a0c8f837f0",
+                "ref": "uuid:7bc386a9-a7de-470d-98b2-85d0db96788d",
                 "orientation": "+"
               }
             ]
@@ -1617,59 +1617,59 @@
   ],
   "shells": [
     {
-      "id": "uuid:7dca4428-0ce0-4082-8df8-78e7f1c760bb",
+      "id": "uuid:08f3c7cd-4b9b-4bdd-a77f-1032c29bd3be",
       "type": "FeatureCollection",
       "featureType": "Shell",
       "features": [
         {
-          "id": "uuid:9ac0d493-ba47-446b-b697-7099fec4f4bd",
+          "id": "uuid:c1c50d16-4ae4-4b00-8df3-169a51b37aad",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Shell",
             "directed_references": [
               {
-                "ref": "uuid:29ecec10-c621-4873-ab17-a45cb95ee321",
+                "ref": "uuid:2ca00a69-cccb-408f-924a-8cb54ddb9fe8",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:f8aa06c7-3c40-4dd9-a029-0b67a4fa0280",
+                "ref": "uuid:88fedfec-2cb7-41f7-8948-dc5a5a2ecf55",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:abedfbd9-9637-4c78-acba-9dc9df413b24",
+                "ref": "uuid:3b3cd92a-5778-408d-8b6f-04b390c7f6fc",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:9784caee-d2dd-4908-9204-14a4280bd726",
+                "ref": "uuid:4f371f0a-c9e0-4f4e-bdcc-d74d495b434f",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:8ac99859-4d85-41e6-a842-0fc7aebec301",
+                "ref": "uuid:113f902b-349b-4e42-98ac-65dc5bfc1e8d",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:472defbe-a781-4b74-8265-5d5cabab5582",
+                "ref": "uuid:b4afb1e1-8688-4be8-9e58-e0fe573ba896",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:d4211a73-0d4b-432d-851d-82c42977ae91",
+                "ref": "uuid:e67afa7f-cf0c-4201-a066-9c5a23a961fa",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:55e9c1cc-0f84-47c9-af2d-97cd017ee0fc",
+                "ref": "uuid:c8d5a816-1012-40de-b696-aacf763e9be4",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:40fde941-9b67-4d4e-9922-051db969d587",
+                "ref": "uuid:da87be42-6980-4503-925d-a61b27eded57",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:f1dafb5b-606d-412b-993d-8da6ce2a39e6",
+                "ref": "uuid:5c11a64f-3b16-45b1-97b5-23e825d38402",
                 "orientation": "+"
               },
               {
-                "ref": "uuid:6790c7df-a754-49ca-b45a-8c70b8fe409d",
+                "ref": "uuid:1de8896f-a293-4c4b-90f6-3670fe0cd761",
                 "orientation": "+"
               }
             ]
@@ -1683,19 +1683,19 @@
   ],
   "solids": [
     {
-      "id": "uuid:be39937f-9c37-4438-abc3-637ca1ce91eb",
+      "id": "uuid:53011530-7534-4cc4-b4cb-21be6a4ccea7",
       "type": "FeatureCollection",
       "featureType": "Solid",
       "features": [
         {
-          "id": "uuid:c961acbd-5816-48af-a288-bc5bbaeaa5da",
+          "id": "uuid:ae57392f-b8f3-412f-bb7a-351a39659606",
           "type": "Feature",
           "geometry": null,
           "topology": {
             "type": "Solid",
             "shells": [
               {
-                "ref": "uuid:9ac0d493-ba47-446b-b697-7099fec4f4bd",
+                "ref": "uuid:c1c50d16-4ae4-4b00-8df3-169a51b37aad",
                 "orientation": "+"
               }
             ]

--- a/_sources/features/topo-feature/examples.yaml
+++ b/_sources/features/topo-feature/examples.yaml
@@ -1,5 +1,6 @@
 - title: Example of a LineString
 
+  base-output-filename: LineString
   snippets:
     - language: json
       ref: examples/linestring.json
@@ -9,6 +10,7 @@
 
 - title: Example of a Polygon
 
+  base-output-filename: Polygon
   snippets:
     - language: json
       ref: examples/polygon.json
@@ -23,6 +25,7 @@
     topology array (type LineString). geometry is null — actual coordinates are resolved
     from the referenced point features at render time.
 
+  base-output-filename: edge-feature
   snippets:
     - language: json
       ref: examples/edge-vertex-refs.json
@@ -30,12 +33,13 @@
       shacl-closure:
         - examples/points2.ttl
 
-- title: Face Feature (Ring/directed_references model)
+- title: Face Feature (directed_references to Ring features)
   content: |
-    A Face feature whose boundary is defined via Ring topology. Each Ring contains a
-    directed_references array of oriented Edge references, each with a 'ref' (Edge feature ID)
-    and 'orientation' ('+' or '-'). geometry is null — geometry is fully defined by the topology.
+    A Face feature referencing Ring features via directed_references. Each element has a
+    'ref' (Ring feature ID) and an 'orientation' ('+' or '-'). geometry is null — geometry
+    is fully defined by the topology.
 
+  base-output-filename: face-feature
   snippets:
     - language: json
       ref: examples/face-edge-refs.json

--- a/_sources/features/topo-feature/examples/face-edge-refs.json
+++ b/_sources/features/topo-feature/examples/face-edge-refs.json
@@ -4,27 +4,10 @@
   "geometry": null,
   "topology": {
     "type": "Face",
-    "rings": [
+    "directed_references": [
       {
-        "type": "Ring",
-        "directed_references": [
-          {
-            "ref": "uuid:c60507ba-226b-4e49-a702-e9afef899b23",
-            "orientation": "+"
-          },
-          {
-            "ref": "uuid:7dc1cc1c-8e7f-4666-9f52-4e6c2e6f57ac",
-            "orientation": "+"
-          },
-          {
-            "ref": "uuid:83ff2cdf-6c58-4e7b-ba55-e084eff8c569",
-            "orientation": "+"
-          },
-          {
-            "ref": "uuid:d69c596c-134e-4216-9bf6-d0f10e6886d8",
-            "orientation": "+"
-          }
-        ]
+        "ref": "uuid:2c21efab-db80-4dd0-96c0-59a63f956d5b",
+        "orientation": "+"
       }
     ]
   },


### PR DESCRIPTION
## PR Type
- [x] `fix` — bug correction
- [x] `refactor` — behaviour-preserving restructure

## Issue

[Fix old examples with incorrect nesting](https://github.com/surroundaustralia/topo-feature/issues/48)

## Scope

Refactored examples failing validation due to incorrect Ring/Face structure

Refactored to follow:

`solids` from **directed** `shells` references, from **directed** `faces` references, from **directed** `ring` references, from **directed** `edges`, from `point` references.

Added base-output-filenames for user clarity

**Refactored** `rings` and `faces` elements in `topo-face` `schema.json` to match other `features.topo-features` schema's. Changed topo-face schema to require directed_references instead of rings. 

**Files changed** in `_sources\alignments`, `_sources\datatypes` and `_sources\features`.

## Testing

Ran local **bblock** validation. All examples passed.